### PR TITLE
Update Trusted Plugins section in README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -58,9 +58,10 @@ mise has the concept of "trusted" and "untrusted" plugins. Trusted plugins will 
 however untrusted plugins will receive the following warning/confirmation:
 
 ```sh-session
-$ mise install zigmod@latest
-⚠️  zigmod is a community-developed plugin: https://github.com/kachick/asdf-zigmod
- Would you like to install zigmod [y/n]?
+$ mise install dprint@latest
+mise ⚠️ dprint is a community-developed plugin
+mise url: https://github.com/asdf-community/asdf-dprint
+ Would you like to install dprint?
 ```
 
 Trusted plugins may be of one of two types, they can be either first-party or hosted in this org with reviewed changes by trusted owners.


### PR DESCRIPTION
Follow https://github.com/mise-plugins/registry/commit/a41b296d7f599de3bccfb31c71da9606fd508216

```console
> mise --version
2024.4.8 linux-x64 (2024-05-02)
```

I don't have any opinions to select dprint for the example. It is only one of the tools that I use, and it is registered in the asdf-community.